### PR TITLE
Support binary payload in RTCDataChannel

### DIFF
--- a/WKWebViewRTC/Classes/WKWebViewRTC.swift
+++ b/WKWebViewRTC/Classes/WKWebViewRTC.swift
@@ -626,7 +626,17 @@ public class WKWebViewRTC : NSObject {
 
 		let pcId = command.argument(at: 0) as! Int
 		let dcId = command.argument(at: 1) as! Int
-		let data = command.argument(at: 2) as! Data
+		let dataArg = command.argument(at: 2);
+		var data: Data?
+		if let base64 = dataArg as? String {
+			data = Data(base64Encoded: base64)
+		} else if let rawData = dataArg as? Data {
+			data = rawData;
+		}
+		guard let data = data else {
+			NSLog("WKWebViewRTC#RTCPeerConnection_RTCDataChannel_sendBinary() | ERROR: data argument is invalid")
+			return;
+		}
 		let pluginRTCPeerConnection = self.pluginRTCPeerConnections[pcId]
 
 		if pluginRTCPeerConnection == nil {

--- a/WKWebViewRTC/Js/jsWKWebViewRTC.js
+++ b/WKWebViewRTC/Js/jsWKWebViewRTC.js
@@ -308,7 +308,7 @@ function setup(env) {
 
 	/**
 	* Selects a color for a debug namespace
-	* @param {String} namespace The namespace string for the for the debug instance to be colored
+	* @param {String} namespace The namespace string for the debug instance to be colored
 	* @return {Number|String} An ANSI color code for the given namespace
 	* @api private
 	*/
@@ -334,6 +334,8 @@ function setup(env) {
 	function createDebug(namespace) {
 		let prevTime;
 		let enableOverride = null;
+		let namespacesCache;
+		let enabledCache;
 
 		function debug(...args) {
 			// Disabled?
@@ -394,7 +396,17 @@ function setup(env) {
 		Object.defineProperty(debug, 'enabled', {
 			enumerable: true,
 			configurable: false,
-			get: () => enableOverride === null ? createDebug.enabled(namespace) : enableOverride,
+			get: () => {
+				if (enableOverride !== null) {
+					return enableOverride;
+				}
+				if (namespacesCache !== createDebug.namespaces) {
+					namespacesCache = createDebug.namespaces;
+					enabledCache = createDebug.enabled(namespace);
+				}
+
+				return enabledCache;
+			},
 			set: v => {
 				enableOverride = v;
 			}
@@ -423,6 +435,7 @@ function setup(env) {
 	*/
 	function enable(namespaces) {
 		createDebug.save(namespaces);
+		createDebug.namespaces = namespaces;
 
 		createDebug.names = [];
 		createDebug.skips = [];
@@ -2743,6 +2756,15 @@ var
 
 debugerror.log = console.warn.bind(console);
 
+function str2ab(base64) {
+	const binaryString = window.atob(base64);
+	const len = binaryString.length;
+	const bytes = new Uint8Array(len);
+	for (var i = 0; i < len; i++) {
+		bytes[i] = binaryString.charCodeAt(i);
+	}
+	return bytes.buffer;
+}
 
 function RTCDataChannel(peerConnection, label, options, dataFromEvent) {
 	var self = this;
@@ -2815,16 +2837,25 @@ function RTCDataChannel(peerConnection, label, options, dataFromEvent) {
 		exec.execNative(onResultOK, null, 'WKWebViewRTC', 'RTCPeerConnection_RTCDataChannel_setListener', [this.peerConnection.pcId, this.dcId]);
 	}
 
-	function onResultOK(data) {
+	function dataToEvent(data) {
 		if (data.type) {
-			onEvent.call(self, data);
-		// Special handler for received binary mesage.
-		} else {
-			onEvent.call(self, {
-				type: 'message',
-				message: data
-			});
+			return data;
 		}
+		if (data.Type === 'ArrayBuffer') {
+			return {
+				type: 'message',
+				message: str2ab(data.Data)
+			}
+		}
+		return {
+			type: 'message',
+			message
+		}
+	}
+
+	function onResultOK(data) {
+		const event = dataToEvent(data);
+		onEvent.call(self, event);
 	}
 }
 
@@ -2843,6 +2874,38 @@ Object.defineProperty(RTCDataChannel.prototype, 'binaryType', {
 	}
 });
 
+function ab2str(arrayBuffer) {
+	let binary_string = ''
+	bytes = new Uint8Array(arrayBuffer);
+	for (let i = 0; i < bytes.byteLength; i++) {
+		binary_string += String.fromCharCode(bytes[i]);
+	}
+	const base64String = window.btoa(binary_string);
+	return base64String;
+}
+
+function getStringRepresentation(data) {
+	let buffer;
+	if (window.ArrayBuffer && data instanceof window.ArrayBuffer) {
+		buffer = data;
+	} else if (
+		(window.Int8Array && data instanceof window.Int8Array) ||
+		(window.Uint8Array && data instanceof window.Uint8Array) ||
+		(window.Uint8ClampedArray && data instanceof window.Uint8ClampedArray) ||
+		(window.Int16Array && data instanceof window.Int16Array) ||
+		(window.Uint16Array && data instanceof window.Uint16Array) ||
+		(window.Int32Array && data instanceof window.Int32Array) ||
+		(window.Uint32Array && data instanceof window.Uint32Array) ||
+		(window.Float32Array && data instanceof window.Float32Array) ||
+		(window.Float64Array && data instanceof window.Float64Array) ||
+		(window.DataView && data instanceof window.DataView)
+	) {
+		buffer = data.buffer;
+	}
+	if (!buffer) throw new Error('Invalid data type');
+
+	return ab2str(buffer);
+}
 
 RTCDataChannel.prototype.send = function (data) {
 	if (isClosed.call(this) || this.readyState !== 'open') {
@@ -2857,23 +2920,9 @@ RTCDataChannel.prototype.send = function (data) {
 
 	if (typeof data === 'string' || data instanceof String) {
 		exec.execNative(null, null, 'WKWebViewRTC', 'RTCPeerConnection_RTCDataChannel_sendString', [this.peerConnection.pcId, this.dcId, data]);
-	} else if (window.ArrayBuffer && data instanceof window.ArrayBuffer) {
-		exec.execNative(null, null, 'WKWebViewRTC', 'RTCPeerConnection_RTCDataChannel_sendBinary', [this.peerConnection.pcId, this.dcId, data]);
-	} else if (
-		(window.Int8Array && data instanceof window.Int8Array) ||
-		(window.Uint8Array && data instanceof window.Uint8Array) ||
-		(window.Uint8ClampedArray && data instanceof window.Uint8ClampedArray) ||
-		(window.Int16Array && data instanceof window.Int16Array) ||
-		(window.Uint16Array && data instanceof window.Uint16Array) ||
-		(window.Int32Array && data instanceof window.Int32Array) ||
-		(window.Uint32Array && data instanceof window.Uint32Array) ||
-		(window.Float32Array && data instanceof window.Float32Array) ||
-		(window.Float64Array && data instanceof window.Float64Array) ||
-		(window.DataView && data instanceof window.DataView)
-	) {
-		exec.execNative(null, null, 'WKWebViewRTC', 'RTCPeerConnection_RTCDataChannel_sendBinary', [this.peerConnection.pcId, this.dcId, data.buffer]);
 	} else {
-		throw new Error('invalid data type');
+		const stringifiedData = getStringRepresentation(data);
+		exec.execNative(null, null, 'WKWebViewRTC', 'RTCPeerConnection_RTCDataChannel_sendBinary', [this.peerConnection.pcId, this.dcId, stringifiedData]);
 	}
 };
 

--- a/WKWebViewRTC/Js/src/RTCDataChannel.js
+++ b/WKWebViewRTC/Js/src/RTCDataChannel.js
@@ -26,6 +26,15 @@ var
 
 debugerror.log = console.warn.bind(console);
 
+function str2ab(base64) {
+	const binaryString = window.atob(base64);
+	const len = binaryString.length;
+	const bytes = new Uint8Array(len);
+	for (var i = 0; i < len; i++) {
+		bytes[i] = binaryString.charCodeAt(i);
+	}
+	return bytes.buffer;
+}
 
 function RTCDataChannel(peerConnection, label, options, dataFromEvent) {
 	var self = this;
@@ -98,16 +107,25 @@ function RTCDataChannel(peerConnection, label, options, dataFromEvent) {
 		exec.execNative(onResultOK, null, 'WKWebViewRTC', 'RTCPeerConnection_RTCDataChannel_setListener', [this.peerConnection.pcId, this.dcId]);
 	}
 
-	function onResultOK(data) {
+	function dataToEvent(data) {
 		if (data.type) {
-			onEvent.call(self, data);
-		// Special handler for received binary mesage.
-		} else {
-			onEvent.call(self, {
-				type: 'message',
-				message: data
-			});
+			return data;
 		}
+		if (data.Type === 'ArrayBuffer') {
+			return {
+				type: 'message',
+				message: str2ab(data.Data)
+			}
+		}
+		return {
+			type: 'message',
+			message
+		}
+	}
+
+	function onResultOK(data) {
+		const event = dataToEvent(data);
+		onEvent.call(self, event);
 	}
 }
 


### PR DESCRIPTION
- Fix sending binary data a6eb5e3ed705f2d91e5c9ca5a36086c0054e4d23
  - `data.buffer` which was at 157 line in `RTCDataChannel.js` before this change was becoming `{}` when it gets to the `WKWebViewRTC.swift` through the bridge. So data was not being sent as expected.
  - I encoded it to string before passing, and then decoded afterwards.
- Fix receiving binary data 5afeb61f19a0519efd6dc564f83d44ea89a539d8
  - Encode and decode received data just like the sent data.
  - `data` field of the first argument(`event`) of `RTCDataChannel.prototype.onmessage` is now `ArrayBuffer` following the native browser API, other than `{ Type: 'ArrayBuffer', Data: string }`